### PR TITLE
Synchronize jerk weight across NLP stages

### DIFF
--- a/campro/optimization/builders.py
+++ b/campro/optimization/builders.py
@@ -41,6 +41,7 @@ def build_nlp_problem_from_stage(params: StageParams, base_meta: Dict[str, Any])
     p_val[pmap['epsilon_valve']] = params.epsilon_valve
     p_val[pmap['epsilon_friction']] = params.epsilon_friction
     p_val[pmap['stress_factor']] = params.stress_factor
+    p_val[pmap['jerk_weight']] = params.jerk_weight
     
     # Construct f(x,p), g(x,p) using current grid/degree/activations
     f, g = base_meta['make_fg'](x, p, params)
@@ -97,6 +98,7 @@ def update_p_val_for_stage(nlp: NLPProblem, params: StageParams) -> NLPProblem:
     p_val[pmap['epsilon_valve']] = params.epsilon_valve
     p_val[pmap['epsilon_friction']] = params.epsilon_friction
     p_val[pmap['stress_factor']] = params.stress_factor
+    p_val[pmap['jerk_weight']] = params.jerk_weight
     
     # Update the NLP problem
     nlp.p_val = p_val

--- a/campro/optimization/enhanced_motion_law_optimizer.py
+++ b/campro/optimization/enhanced_motion_law_optimizer.py
@@ -335,7 +335,8 @@ class EnhancedMotionLawOptimizer:
             'grid': grid,
             'n': n,
             'motion_params': motion_params,
-            'base_meta': self.base_meta  # Add base_meta for robust continuation
+            'base_meta': self.base_meta,  # Add base_meta for robust continuation
+            'jerk_weight': self.params.jerk_weight
         }
         
         self.logger.info(f"Enhanced NLP formulation complete: {3*n-3} variables, {g.shape[0]} constraints")

--- a/campro/optimization/nlp_types.py
+++ b/campro/optimization/nlp_types.py
@@ -20,6 +20,7 @@ class StageParams:
     epsilon_valve: float
     epsilon_friction: float
     stress_factor: float
+    jerk_weight: float
     grid_nodes: int
     colloc_degree: int
     enable_constraints: Dict[str, bool]  # e.g., {"stress": True, "jerk": True}

--- a/campro/optimization/solver_improvements.py
+++ b/campro/optimization/solver_improvements.py
@@ -819,12 +819,36 @@ class ContinuationStrategy:
         from .builders import build_nlp_problem_from_stage, update_p_val_for_stage, should_rebuild_nlp
         
         stage_problem = deepcopy(base_problem)
-        
+
+        # Determine jerk weight for this stage
+        stage_params = dict(stage_params)
+        jerk_weight = stage_params.get('jerk_weight')
+
+        if jerk_weight is None:
+            # Check if existing stage problem already stored a jerk weight
+            jerk_weight = stage_problem.get('jerk_weight')
+
+        if jerk_weight is None and stage_problem.get('nlp_problem') is not None:
+            prev_stage_params = stage_problem['nlp_problem'].meta.get('stage_params')
+            if prev_stage_params is not None and hasattr(prev_stage_params, 'jerk_weight'):
+                jerk_weight = prev_stage_params.jerk_weight
+
+        if jerk_weight is None and 'motion_law_optimizer' in stage_problem:
+            optimizer = stage_problem['motion_law_optimizer']
+            jerk_weight = getattr(getattr(optimizer, 'params', None), 'jerk_weight', None)
+
+        if jerk_weight is None:
+            # Fallback to zero to avoid None values propagating into the NLP parameters
+            jerk_weight = 0.0
+
+        stage_params['jerk_weight'] = jerk_weight
+
         # Convert stage_params to StageParams object
         stage_params_obj = StageParams(
             epsilon_valve=stage_params['epsilon_valve'],
             epsilon_friction=stage_params['epsilon_friction'],
             stress_factor=stage_params['stress_factor'],
+            jerk_weight=stage_params['jerk_weight'],
             grid_nodes=stage_params.get('grid_nodes', 32),
             colloc_degree=stage_params.get('colloc_degree', 1),
             enable_constraints=stage_params.get('enable_constraints', {}),
@@ -905,6 +929,7 @@ class ContinuationStrategy:
         # Update stage metadata
         stage_problem['stage_number'] = stage_number
         stage_problem['stage_params'] = stage_params
+        stage_problem['jerk_weight'] = jerk_weight
         
         # Log stage information
         self.logger.info(f"Created Stage {stage_number}: {stage_params['description']}")

--- a/tests/test_enhanced_optimizers.py
+++ b/tests/test_enhanced_optimizers.py
@@ -14,6 +14,8 @@ import casadi as ca
 from campro.optimization.enhanced_motion_law_optimizer import (
     EnhancedMotionLawParameters, EnhancedMotionLawOptimizer
 )
+from campro.optimization.builders import build_nlp_problem_from_stage
+from campro.optimization.nlp_types import StageParams
 from campro.optimization.enhanced_gear_optimizer import (
     EnhancedGearParameters, EnhancedGearOptimizer
 )
@@ -162,25 +164,58 @@ class TestEnhancedMotionLawOptimizer:
             'samplingStepDeg': 10.0,
             'compressionDurationPercent': 70.0
         }
-        
+
         grid = optimizer._create_motion_law_grid(motion_params)
         x0 = optimizer._create_enhanced_initial_guess(grid, motion_params)
-        
+
         # Check that initial guess is created
         assert isinstance(x0, np.ndarray)
         assert len(x0) > 0
-        
+
         # Check that initial guess has reasonable values
         # Displacement and velocity should be non-negative, acceleration can be negative
         n_grid = len(grid)
         displacement = x0[:n_grid]
         velocity = x0[n_grid:n_grid+n_grid-1]
         acceleration = x0[n_grid+n_grid-1:]  # noqa: F841
-        
+
         assert np.all(displacement >= 0.0)  # Displacement should be non-negative
         assert np.all(velocity >= 0.0)  # Velocity should be non-negative
         # Acceleration can be negative, so we don't check it
-    
+
+    def test_jerk_weight_penalty_affects_objective(self, optimizer):
+        """Ensure non-zero jerk weight adds to the objective."""
+        stage_params = StageParams(
+            epsilon_valve=1e-2,
+            epsilon_friction=1e-2,
+            stress_factor=1.0,
+            jerk_weight=1e-3,
+            grid_nodes=5,
+            colloc_degree=1,
+            enable_constraints={'jerk': True},
+            tolerance=1e-6,
+            max_iter=100,
+            description='Unit test stage'
+        )
+
+        nlp = build_nlp_problem_from_stage(stage_params, optimizer.base_meta)
+        pmap = optimizer.base_meta['pmap']
+
+        # Construct a state vector with non-zero jerk contribution
+        x_disp = np.linspace(0.0, 1.0, stage_params.grid_nodes)
+        v = np.array([0.1, 0.2, 0.1, 0.05])
+        a = np.array([0.0, 1.0, -0.5])
+        x_test = np.concatenate([x_disp, v, a])
+
+        p_nonzero = np.array(nlp.p_val, copy=True)
+        p_zero = np.array(nlp.p_val, copy=True)
+        p_zero[pmap['jerk_weight']] = 0.0
+
+        obj_with_jerk = float(nlp.fun(x_test, p_nonzero))
+        obj_without_jerk = float(nlp.fun(x_test, p_zero))
+
+        assert obj_with_jerk > obj_without_jerk
+
     def test_thermodynamic_data_calculation(self, optimizer):
         """Test thermodynamic data calculation."""
         # Create test data - asymmetric cycle to get positive work


### PR DESCRIPTION
## Summary
- include the jerk_weight scalar in stage parameters and write it into the NLP parameter vector during builds and updates
- carry the jerk weight through continuation metadata so solver-improvement stages reuse the correct penalty strength
- add a regression test ensuring a non-zero jerk weight contributes to the objective value

## Testing
- pytest tests/test_enhanced_optimizers.py::TestEnhancedMotionLawOptimizer *(fails: ImportError for libGL.so.1 from Qt dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff5007fe48323a5b3c348829c738c