### PR TITLE
Use motion-law grid when constructing enhanced NLP

### DIFF
--- a/campro/optimization/builders.py
+++ b/campro/optimization/builders.py
@@ -24,7 +24,15 @@ def build_nlp_problem_from_stage(params: StageParams, base_meta: Dict[str, Any])
         Complete NLPProblem with compiled functions and structure signature
     """
     # Extract structural parameters
-    N = params.grid_nodes
+    grid = getattr(params, 'grid', None)
+    if grid is not None:
+        grid = np.asarray(grid, dtype=float)
+        N = grid.shape[0]
+        if params.grid_nodes != N:
+            params.grid_nodes = N
+        params.grid = grid
+    else:
+        N = params.grid_nodes
     deg = params.colloc_degree
     act = params.enable_constraints
     
@@ -64,6 +72,7 @@ def build_nlp_problem_from_stage(params: StageParams, base_meta: Dict[str, Any])
         'stage_params': params,
         'pmap': pmap,
         'np': np_total,
+        'grid': grid,
         **base_meta
     }
     

--- a/campro/optimization/enhanced_motion_law_optimizer.py
+++ b/campro/optimization/enhanced_motion_law_optimizer.py
@@ -245,12 +245,13 @@ class EnhancedMotionLawOptimizer:
         
         # Create stage parameters for consistency
         class DummyStageParams:
-            def __init__(self, n, max_vel, max_acc):
+            def __init__(self, n, max_vel, max_acc, grid_vals):
                 self.grid_nodes = n
                 self.colloc_degree = 1
                 self.enable_constraints = {'stress': True, 'jerk': True}
-        
-        stage_params = DummyStageParams(n, max_velocity, max_acceleration)
+                self.grid = np.asarray(grid_vals, dtype=float)
+
+        stage_params = DummyStageParams(n, max_velocity, max_acceleration, grid)
         
         # Use _make_fg to build consistent constraints
         f, g = self._make_fg(x_all, p, stage_params)
@@ -894,8 +895,16 @@ class EnhancedMotionLawOptimizer:
         v = x[n:n+(n-1)]
         a = x[n+(n-1):]
         
-        # Create grid
-        grid = np.linspace(0, 2*np.pi, N)
+        # Use provided grid if available, otherwise fall back to a uniform grid
+        grid = getattr(params, 'grid', None)
+        if grid is not None:
+            grid = np.asarray(grid, dtype=float)
+            if grid.shape[0] != N:
+                raise ValueError(
+                    f"Stage grid length {grid.shape[0]} does not match grid_nodes {N}"
+                )
+        else:
+            grid = np.linspace(0, 2 * np.pi, N)
         
         # Extract parameters from p vector
         pmap = self.base_meta['pmap']

--- a/campro/optimization/nlp_types.py
+++ b/campro/optimization/nlp_types.py
@@ -8,7 +8,7 @@ the interface between solver, diagnostics, and tests.
 from dataclasses import dataclass
 import casadi as ca
 import numpy as np
-from typing import Dict, Any, Tuple
+from typing import Dict, Any, Tuple, Optional
 from campro.logging import get_logger
 
 logger = get_logger(__name__)
@@ -26,6 +26,7 @@ class StageParams:
     tolerance: float
     max_iter: int
     description: str
+    grid: Optional[np.ndarray] = None
 
 
 @dataclass

--- a/campro/optimization/solver_improvements.py
+++ b/campro/optimization/solver_improvements.py
@@ -820,23 +820,45 @@ class ContinuationStrategy:
         
         stage_problem = deepcopy(base_problem)
         
+        # Determine the grid associated with this stage
+        grid = stage_problem.get('grid', None)
+        if grid is None and 'nlp_problem' in stage_problem and stage_problem['nlp_problem'] is not None:
+            nlp_meta = stage_problem['nlp_problem'].meta
+            grid = nlp_meta.get('grid_t') or nlp_meta.get('grid')
+
+        if grid is not None:
+            grid = np.asarray(grid, dtype=float)
+            grid_nodes = grid.shape[0]
+        else:
+            grid_nodes = stage_params.get('grid_nodes', 32)
+
         # Convert stage_params to StageParams object
         stage_params_obj = StageParams(
             epsilon_valve=stage_params['epsilon_valve'],
             epsilon_friction=stage_params['epsilon_friction'],
             stress_factor=stage_params['stress_factor'],
-            grid_nodes=stage_params.get('grid_nodes', 32),
+            grid_nodes=grid_nodes,
             colloc_degree=stage_params.get('colloc_degree', 1),
             enable_constraints=stage_params.get('enable_constraints', {}),
             tolerance=stage_params['tolerance'],
             max_iter=stage_params['max_iter'],
-            description=stage_params['description']
+            description=stage_params['description'],
+            grid=grid
         )
         
         # Apply grid refinement for later stages
         if stage_number > 1:
             stage_problem = self._refine_grid(stage_problem, stage_number)
-            stage_params_obj.grid_nodes = stage_problem.get('grid_nodes', stage_params_obj.grid_nodes)
+            refined_grid = stage_problem.get('grid', stage_params_obj.grid)
+            if refined_grid is None and 'nlp_problem' in stage_problem and stage_problem['nlp_problem'] is not None:
+                nlp_meta = stage_problem['nlp_problem'].meta
+                refined_grid = nlp_meta.get('grid_t') or nlp_meta.get('grid')
+
+            if refined_grid is not None:
+                stage_params_obj.grid = np.asarray(refined_grid, dtype=float)
+                stage_params_obj.grid_nodes = stage_params_obj.grid.shape[0]
+            else:
+                stage_params_obj.grid_nodes = stage_problem.get('grid_nodes', stage_params_obj.grid_nodes)
         
         # Get base metadata for NLP building
         base_meta = None


### PR DESCRIPTION
## Summary
- extend `StageParams` and the NLP builders to carry the physical motion-law grid
- update the enhanced motion law optimizer and continuation strategy to reuse the supplied grid when forming `f` and `g`

## Testing
- pytest tests/test_enhanced_optimizers.py::TestEnhancedMotionLawOptimizer::test_motion_law_optimization *(fails: missing libGL.so.1 in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff4f9c6d08323afc2b512806e351f