### PR TITLE
Normalize ring cycle units to percent across optimization pipeline

### DIFF
--- a/campro/gears/profile_generator.py
+++ b/campro/gears/profile_generator.py
@@ -9,6 +9,14 @@ import numpy as np
 from typing import Dict, List, Tuple, Any
 import logging
 
+from campro.utils.angle_units import (
+    ensure_percent_grid,
+    percent_to_degrees,
+    percent_to_radians,
+    resolve_cycle_percent,
+    degrees_to_percent,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,11 +46,16 @@ class GearProfileGenerator:
         """
         self.logger.info("Generating motion law using piecewise method with proper acceleration profile...")
         
-        # CORRECTED: Generate motion law for 180° ring rotation (planetary gearset)
-        # The motion law should span 180° ring rotation for complete 2-stroke cycle
-        ring_rotation_deg = params["ringRotationDeg"]  # 180°
-        theta_deg = np.arange(0, ring_rotation_deg, params["samplingStepDeg"])
-        n = len(theta_deg)
+        # CORRECTED: Generate motion law using percent of the ring rotation.
+        ring_rotation_pct = resolve_cycle_percent(params, "ringRotation")
+        sampling_step_pct = ensure_percent_grid(
+            resolve_cycle_percent(params, "samplingStep")
+        )
+
+        theta_pct = np.arange(0.0, ring_rotation_pct, sampling_step_pct)
+        theta_rad = percent_to_radians(theta_pct)
+        theta_deg = percent_to_degrees(theta_pct)
+        n = len(theta_pct)
         
         # Initialize arrays
         displacement = np.zeros(n)
@@ -51,16 +64,20 @@ class GearProfileGenerator:
         
         # Motion law parameters
         stroke_length = params["strokeLengthMm"]  # Full stroke length in mm
-        ramp_before_tdc = params["rampBeforeTdcDeg"]
-        ramp_after_tdc = params["rampAfterTdcDeg"]
-        dwell_tdc = params["dwellTdcDeg"]
-        ramp_before_bdc = params["rampBeforeBdcDeg"]
-        ramp_after_bdc = params["rampAfterBdcDeg"]
-        dwell_bdc = params["dwellBdcDeg"]
-        
+        ramp_before_tdc = resolve_cycle_percent(params, "rampBeforeTdc")
+        ramp_after_tdc = resolve_cycle_percent(params, "rampAfterTdc")
+        dwell_tdc = resolve_cycle_percent(params, "dwellTdc")
+        ramp_before_bdc = resolve_cycle_percent(params, "rampBeforeBdc")
+        ramp_after_bdc = resolve_cycle_percent(params, "rampAfterBdc")
+        dwell_bdc = resolve_cycle_percent(params, "dwellBdc")
+
         # Calculate phase boundaries (FIXED: use parameterized values)
-        constant_velocity_tdc = params.get("constantVelocityTdcDeg", 30.0)
-        constant_velocity_bdc = params.get("constantVelocityBdcDeg", 40.0)
+        constant_velocity_tdc = resolve_cycle_percent(
+            params, "constantVelocityTdc", default_percent=degrees_to_percent(30.0)
+        )
+        constant_velocity_bdc = resolve_cycle_percent(
+            params, "constantVelocityBdc", default_percent=degrees_to_percent(40.0)
+        )
         
         # CORRECTED: Motion law represents piston stroke from BDC (0) to TDC (stroke_length)
         # Phase 1: Acceleration from BDC to constant velocity
@@ -80,10 +97,10 @@ class GearProfileGenerator:
         # Phase 8: Dwell at BDC (zero displacement)
         phase8_end = phase7_end + dwell_tdc
         
-        # Scale phases to fit 180° ring rotation
+        # Scale phases to fit requested ring rotation percent
         total_phases = phase8_end
-        scale_factor = ring_rotation_deg / total_phases
-        
+        scale_factor = ring_rotation_pct / total_phases
+
         phase1_end *= scale_factor
         phase2_end *= scale_factor
         phase3_end *= scale_factor
@@ -92,73 +109,202 @@ class GearProfileGenerator:
         phase6_end *= scale_factor
         phase7_end *= scale_factor
         phase8_end *= scale_factor
-        
-        self.logger.info(f"Motion law phases (scaled to {ring_rotation_deg}°):")
-        self.logger.info(f"  0-{phase1_end:.1f}°: Acceleration from BDC to constant velocity")
-        self.logger.info(f"  {phase1_end:.1f}-{phase2_end:.1f}°: Constant velocity during upstroke")
-        self.logger.info(f"  {phase2_end:.1f}-{phase3_end:.1f}°: Deceleration to dwell at TDC")
-        self.logger.info(f"  {phase3_end:.1f}-{phase4_end:.1f}°: Dwell at TDC (max displacement: {stroke_length}mm)")
-        self.logger.info(f"  {phase4_end:.1f}-{phase5_end:.1f}°: Acceleration from TDC to constant velocity")
-        self.logger.info(f"  {phase5_end:.1f}-{phase6_end:.1f}°: Constant velocity during downstroke")
-        self.logger.info(f"  {phase6_end:.1f}-{phase7_end:.1f}°: Deceleration to dwell at BDC")
-        self.logger.info(f"  {phase7_end:.1f}-{phase8_end:.1f}°: Dwell at BDC (zero displacement)")
+
+        self.logger.info(
+            f"Motion law phases (scaled to {ring_rotation_pct:.3f}% of cycle):"
+        )
+        self.logger.info(
+            "  0-{:.3f}%: Acceleration from BDC to constant velocity".format(phase1_end)
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Constant velocity during upstroke".format(
+                phase1_end, phase2_end
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Deceleration to dwell at TDC".format(
+                phase2_end, phase3_end
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Dwell at TDC (max displacement: {}mm)".format(
+                phase3_end, phase4_end, stroke_length
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Acceleration from TDC to constant velocity".format(
+                phase4_end, phase5_end
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Constant velocity during downstroke".format(
+                phase5_end, phase6_end
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Deceleration to dwell at BDC".format(
+                phase6_end, phase7_end
+            )
+        )
+        self.logger.info(
+            "  {:.3f}-{:.3f}%: Dwell at BDC (zero displacement)".format(
+                phase7_end, phase8_end
+            )
+        )
+
+        phase1_end_rad = percent_to_radians(phase1_end)
+        phase2_end_rad = percent_to_radians(phase2_end)
+        phase3_end_rad = percent_to_radians(phase3_end)
+        phase4_end_rad = percent_to_radians(phase4_end)
+        phase5_end_rad = percent_to_radians(phase5_end)
+        phase6_end_rad = percent_to_radians(phase6_end)
+        phase7_end_rad = percent_to_radians(phase7_end)
+        phase8_end_rad = percent_to_radians(phase8_end)
         
         # Generate motion law - CORRECTED to represent proper piston stroke
-        for i, theta in enumerate(theta_deg):
-            if theta <= phase1_end:
+        for i, (theta_percent, theta_value_rad) in enumerate(zip(theta_pct, theta_rad)):
+            if theta_percent <= phase1_end:
                 # Phase 1: Acceleration from BDC to constant velocity during upstroke
-                beta = theta / phase1_end
-                displacement[i] = stroke_length * 0.5 * (beta - np.sin(2 * np.pi * beta) / (2 * np.pi))
-                velocity[i] = stroke_length * 0.5 * (1 - np.cos(2 * np.pi * beta)) / (2 * np.pi * phase1_end * np.pi / 180)
-                acceleration[i] = stroke_length * 0.5 * np.sin(2 * np.pi * beta) / (phase1_end * np.pi / 180)**2
-                
-            elif theta <= phase2_end:
+                if phase1_end_rad == 0.0:
+                    beta = 0.0
+                else:
+                    beta = theta_value_rad / phase1_end_rad
+                displacement[i] = stroke_length * 0.5 * (
+                    beta - np.sin(2 * np.pi * beta) / (2 * np.pi)
+                )
+                if phase1_end_rad:
+                    velocity[i] = (
+                        stroke_length
+                        * 0.5
+                        * (1 - np.cos(2 * np.pi * beta))
+                        / phase1_end_rad
+                    )
+                    acceleration[i] = (
+                        stroke_length
+                        * np.pi
+                        * np.sin(2 * np.pi * beta)
+                        / (phase1_end_rad**2)
+                    )
+                else:
+                    velocity[i] = 0.0
+                    acceleration[i] = 0.0
+
+            elif theta_percent <= phase2_end:
                 # Phase 2: Constant velocity during upstroke
-                displacement[i] = stroke_length * 0.5 + stroke_length * 0.5 * (theta - phase1_end) / (phase2_end - phase1_end)
-                velocity[i] = stroke_length * 0.5 / (phase2_end - phase1_end) * np.pi / 180
+                displacement[i] = stroke_length * 0.5 + stroke_length * 0.5 * (
+                    (theta_percent - phase1_end) / (phase2_end - phase1_end)
+                )
+                if phase2_end_rad > phase1_end_rad:
+                    velocity[i] = (
+                        stroke_length
+                        * 0.5
+                        / (phase2_end_rad - phase1_end_rad)
+                    )
+                else:
+                    velocity[i] = 0.0
                 acceleration[i] = 0.0
-                
-            elif theta <= phase3_end:
-                # Phase 3: Deceleration to dwell at TDC (stay at max displacement, decelerate to zero velocity)
-                beta = (theta - phase2_end) / (phase3_end - phase2_end)
-                displacement[i] = stroke_length  # Stay at maximum displacement during deceleration to dwell
-                # Decelerate from constant velocity to zero velocity
-                velocity[i] = stroke_length * 0.5 * (1 - beta) / (phase2_end - phase1_end) * np.pi / 180
-                acceleration[i] = -stroke_length * 0.5 / (phase2_end - phase1_end) / (phase3_end - phase2_end) * np.pi / 180
-                
-            elif theta <= phase4_end:
+
+            elif theta_percent <= phase3_end:
+                # Phase 3: Deceleration to dwell at TDC (stay at max displacement)
+                beta = (theta_percent - phase2_end) / (phase3_end - phase2_end)
+                displacement[i] = stroke_length
+                if phase2_end_rad > phase1_end_rad:
+                    velocity[i] = (
+                        stroke_length
+                        * 0.5
+                        * (1 - beta)
+                        / (phase2_end_rad - phase1_end_rad)
+                    )
+                else:
+                    velocity[i] = 0.0
+                if (phase2_end_rad > phase1_end_rad) and (phase3_end_rad > phase2_end_rad):
+                    acceleration[i] = (
+                        -stroke_length
+                        * 0.5
+                        / (phase2_end_rad - phase1_end_rad)
+                        / (phase3_end_rad - phase2_end_rad)
+                    )
+                else:
+                    acceleration[i] = 0.0
+
+            elif theta_percent <= phase4_end:
                 # Phase 4: Dwell at TDC (maximum displacement)
                 displacement[i] = stroke_length
                 velocity[i] = 0.0
                 acceleration[i] = 0.0
-                
-            elif theta <= phase5_end:
+
+            elif theta_percent <= phase5_end:
                 # Phase 5: Acceleration from TDC to constant velocity during downstroke
-                beta = (theta - phase4_end) / (phase5_end - phase4_end)
-                displacement[i] = stroke_length * (1 - 0.5 * (beta - np.sin(2 * np.pi * beta) / (2 * np.pi)))
-                velocity[i] = -stroke_length * 0.5 * (1 - np.cos(2 * np.pi * beta)) / (2 * np.pi * (phase5_end - phase4_end) * np.pi / 180)
-                acceleration[i] = -stroke_length * 0.5 * np.sin(2 * np.pi * beta) / ((phase5_end - phase4_end) * np.pi / 180)**2
-                
-            elif theta <= phase6_end:
+                if phase5_end_rad > phase4_end_rad:
+                    beta = (theta_value_rad - phase4_end_rad) / (
+                        phase5_end_rad - phase4_end_rad
+                    )
+                else:
+                    beta = 0.0
+                displacement[i] = stroke_length * (
+                    1 - 0.5 * (beta - np.sin(2 * np.pi * beta) / (2 * np.pi))
+                )
+                if phase5_end_rad > phase4_end_rad:
+                    velocity[i] = (
+                        -stroke_length
+                        * 0.5
+                        * (1 - np.cos(2 * np.pi * beta))
+                        / (phase5_end_rad - phase4_end_rad)
+                    )
+                    acceleration[i] = (
+                        -stroke_length
+                        * np.pi
+                        * np.sin(2 * np.pi * beta)
+                        / (phase5_end_rad - phase4_end_rad) ** 2
+                    )
+                else:
+                    velocity[i] = 0.0
+                    acceleration[i] = 0.0
+
+            elif theta_percent <= phase6_end:
                 # Phase 6: Constant velocity during downstroke
-                displacement[i] = stroke_length * 0.5 - stroke_length * 0.5 * (theta - phase5_end) / (phase6_end - phase5_end)
-                velocity[i] = -stroke_length * 0.5 / (phase6_end - phase5_end) * np.pi / 180
+                displacement[i] = stroke_length * 0.5 - stroke_length * 0.5 * (
+                    (theta_percent - phase5_end) / (phase6_end - phase5_end)
+                )
+                if phase6_end_rad > phase5_end_rad:
+                    velocity[i] = (
+                        -stroke_length
+                        * 0.5
+                        / (phase6_end_rad - phase5_end_rad)
+                    )
+                else:
+                    velocity[i] = 0.0
                 acceleration[i] = 0.0
-                
-            elif theta <= phase7_end:
-                # Phase 7: Deceleration to dwell at BDC (stay at zero displacement, decelerate to zero velocity)
-                beta = (theta - phase6_end) / (phase7_end - phase6_end)
-                displacement[i] = 0.0  # Stay at zero displacement during deceleration to dwell at BDC
-                # Decelerate from constant velocity to zero velocity
-                velocity[i] = -stroke_length * 0.5 * (1 - beta) / (phase6_end - phase5_end) * np.pi / 180
-                acceleration[i] = stroke_length * 0.5 / (phase6_end - phase5_end) / (phase7_end - phase6_end) * np.pi / 180
-                
-            elif theta <= phase8_end:
+
+            elif theta_percent <= phase7_end:
+                # Phase 7: Deceleration to dwell at BDC
+                beta = (theta_percent - phase6_end) / (phase7_end - phase6_end)
+                displacement[i] = 0.0
+                if phase6_end_rad > phase5_end_rad:
+                    velocity[i] = (
+                        -stroke_length
+                        * 0.5
+                        * (1 - beta)
+                        / (phase6_end_rad - phase5_end_rad)
+                    )
+                else:
+                    velocity[i] = 0.0
+                if (phase6_end_rad > phase5_end_rad) and (phase7_end_rad > phase6_end_rad):
+                    acceleration[i] = (
+                        stroke_length
+                        * 0.5
+                        / (phase6_end_rad - phase5_end_rad)
+                        / (phase7_end_rad - phase6_end_rad)
+                    )
+                else:
+                    acceleration[i] = 0.0
+
+            elif theta_percent <= phase8_end:
                 # Phase 8: Dwell at BDC (zero displacement)
                 displacement[i] = 0.0
                 velocity[i] = 0.0
                 acceleration[i] = 0.0
-                
+
             else:
                 # Beyond defined phases - should not happen
                 displacement[i] = 0.0
@@ -185,8 +331,11 @@ class GearProfileGenerator:
         self.logger.info("Generating UNIFIED gear profiles using displacement and connecting rod length...")
 
         n = len(theta_deg)
-        step_deg = params["samplingStepDeg"]
-        step_rad = np.deg2rad(step_deg)
+        step_percent = ensure_percent_grid(
+            resolve_cycle_percent(params, "samplingStep")
+        )
+        step_deg = percent_to_degrees(step_percent)
+        step_rad = percent_to_radians(step_percent)
 
         # UNIFIED CONSTRAINT SYSTEM WITH DISPLACEMENT AND CONNECTING ROD
         # ===============================================================
@@ -569,7 +718,9 @@ class GearProfileGenerator:
         sun_center_radius = params.get("journalRadius", 5.0)  # 5.0 mm default
         
         planet_count = int(params.get("planetCount", 2))
-        carrier_offset_deg = float(params.get("carrierOffsetDeg", 180.0))
+        carrier_offset_deg = percent_to_degrees(
+            resolve_cycle_percent(params, "carrierOffset", default_percent=degrees_to_percent(180.0))
+        )
         
         planets = []
         
@@ -599,10 +750,14 @@ class GearProfileGenerator:
             # For now, we'll place it at a fixed offset from the COM
             # This should be calculated based on the actual connecting rod geometry
             journal_offset_radius = params.get("journalOffsetRadius", 5.0)  # mm offset from COM
-            journal_angle_offset = params.get("journalAngleOffset", 0.0)  # degrees offset from COM
+            journal_angle_offset_deg = percent_to_degrees(
+                resolve_cycle_percent(
+                    params, "journalAngleOffset", default_percent=degrees_to_percent(0.0)
+                )
+            )  # offset from COM
             
             # Journal position relative to planet COM
-            journal_angle_rad = np.deg2rad(psi_deg + journal_angle_offset)
+            journal_angle_rad = np.deg2rad(psi_deg + journal_angle_offset_deg)
             journal_x = center_x + journal_offset_radius * np.cos(journal_angle_rad)
             journal_y = center_y + journal_offset_radius * np.sin(journal_angle_rad)
             
@@ -621,7 +776,8 @@ class GearProfileGenerator:
                 "journal_x": journal_x,
                 "journal_y": journal_y,
                 "journal_offset_radius": journal_offset_radius,
-                "journal_angle_offset": journal_angle_offset
+                "journal_angle_offset_deg": journal_angle_offset_deg,
+                "journal_angle_offset_percent": degrees_to_percent(journal_angle_offset_deg),
             })
         
         return planets

--- a/campro/optimization/enhanced_gear_optimizer.py
+++ b/campro/optimization/enhanced_gear_optimizer.py
@@ -22,6 +22,13 @@ from campro.physics.transmission import (
     TransmissionEfficiency, ContactMechanics, FrictionModel, TransmissionOptimizer
 )
 from campro.optimization.solver_improvements import SolverParameters, SolverImprovements
+from campro.utils.angle_units import (
+    ensure_percent_grid,
+    percent_to_degrees,
+    percent_to_radians,
+    resolve_cycle_percent,
+    degrees_to_percent,
+)
 
 log = get_logger(__name__)
 
@@ -193,14 +200,16 @@ class EnhancedGearOptimizer:
         """Create collocation grid for gear profile optimization."""
         self.logger.info("Creating gear profile collocation grid")
         
-        # Use the same grid as motion law for consistency
-        gear_grid = np.deg2rad(theta_grid)
-        
-        # Ensure proper scaling for gear optimization
-        ring_rotation_deg = gear_params.get('ringRotationDeg', 180.0)
-        scale_factor = 2 * np.pi / ring_rotation_deg
+        # Use the same grid as motion law for consistency but normalise units
+        theta_percent = degrees_to_percent(theta_grid)
+        gear_grid = percent_to_radians(theta_percent)
+
+        ring_rotation_percent = resolve_cycle_percent(
+            gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+        scale_factor = (2 * np.pi) / percent_to_radians(ring_rotation_percent)
         gear_grid = gear_grid * scale_factor
-        
+
         self.logger.info(f"Gear collocation grid created with {len(gear_grid)} points")
         return gear_grid
     
@@ -404,9 +413,11 @@ class EnhancedGearOptimizer:
         noslip_residual = r_inst * planet_radius - ring_radius
         
         # Global integral residual
-        ring_rotation_deg = gear_params.get('ringRotationDeg', 180.0)
-        step_deg = ring_rotation_deg / (n - 1) if n > 1 else ring_rotation_deg
-        integral_r = ca.sum1(r_inst) * step_deg
+        ring_rotation_percent = resolve_cycle_percent(
+            gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+        step_percent = ring_rotation_percent / (n - 1) if n > 1 else ring_rotation_percent
+        integral_r = ca.sum1(r_inst) * percent_to_radians(step_percent)
         expected_integral = 2.0 * np.pi
         integral_residual = integral_r - expected_integral
         
@@ -777,7 +788,13 @@ class EnhancedGearOptimizer:
         if len(theta_grid_deg) > 1:
             step_deg = float(theta_grid_deg[1] - theta_grid_deg[0])
         else:
-            step_deg = float(gear_params.get('ringRotationDeg', 180.0))
+            step_deg = float(
+                percent_to_degrees(
+                    resolve_cycle_percent(
+                        gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+                    )
+                )
+            )
         
         if n > 1:
             accumulated_phi_deg = float(np.sum(r_inst[:n-1]) * step_deg)

--- a/campro/optimization/enhanced_motion_law_optimizer.py
+++ b/campro/optimization/enhanced_motion_law_optimizer.py
@@ -22,6 +22,13 @@ from campro.physics.thermodynamics import (
     CombustionModel, StateEquations, ThermodynamicOptimizer
 )
 from campro.optimization.solver_improvements import SolverParameters, SolverImprovements
+from campro.utils.angle_units import (
+    ensure_percent_grid,
+    percent_to_degrees,
+    percent_to_radians,
+    resolve_cycle_percent,
+    degrees_to_percent,
+)
 
 log = get_logger(__name__)
 
@@ -192,15 +199,27 @@ class EnhancedMotionLawOptimizer:
     
     def _create_motion_law_grid(self, motion_params: Dict[str, Any]) -> np.ndarray:
         """Create grid for motion law optimization."""
-        ring_rotation_deg = motion_params.get('ringRotationDeg', 180.0)
-        sampling_step_deg = motion_params.get('samplingStepDeg', 5.0)
-        
-        # Create grid from 0 to ring_rotation_deg
-        n_points = int(ring_rotation_deg / sampling_step_deg) + 1
-        grid_deg = np.linspace(0, ring_rotation_deg, n_points)
-        grid_rad = np.radians(grid_deg)
-        
-        self.logger.info(f"Created motion law grid: {n_points} points from 0° to {ring_rotation_deg}°")
+        ring_rotation_percent = resolve_cycle_percent(
+            motion_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+        sampling_step_percent = ensure_percent_grid(
+            resolve_cycle_percent(
+                motion_params, 'samplingStep', default_percent=degrees_to_percent(5.0)
+            )
+        )
+
+        if sampling_step_percent <= 0:
+            raise ValueError("samplingStep must be positive")
+
+        n_points = int(np.floor(ring_rotation_percent / sampling_step_percent + 1e-9)) + 1
+        grid_percent = np.linspace(0.0, ring_rotation_percent, n_points)
+        grid_rad = percent_to_radians(grid_percent)
+
+        self.logger.info(
+            "Created motion law grid: %d points from 0%% to %.3f%% of cycle",
+            n_points,
+            ring_rotation_percent,
+        )
         return grid_rad
     
     def _build_enhanced_nlp_formulation(self, motion_params: Dict[str, Any], 
@@ -224,16 +243,29 @@ class EnhancedMotionLawOptimizer:
         # Extract user parameters
         stroke_length_m = motion_params.get('strokeLengthMm', 10.0) / 1000.0  # Convert to meters
         compression_duration_percent = motion_params.get('compressionDurationPercent', 70.0)
-        ring_rotation_deg = motion_params.get('ringRotationDeg', 180.0)
-        
-        # Calculate phase durations
-        total_duration_deg = ring_rotation_deg
-        compression_duration_deg = (compression_duration_percent / 100.0) * total_duration_deg
+        ring_rotation_percent = resolve_cycle_percent(
+            motion_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+
+        # Calculate phase durations using consistent units
+        total_duration_deg = percent_to_degrees(ring_rotation_percent)
+        compression_duration_deg = (
+            compression_duration_percent / 100.0
+        ) * total_duration_deg
+        expansion_duration_percent = 100.0 - compression_duration_percent
         expansion_duration_deg = total_duration_deg - compression_duration_deg
-        
+
         self.logger.info("Enhanced motion law phases with thermodynamics:")
-        self.logger.info(f"  Compression: {compression_duration_deg:.1f}° ({compression_duration_percent}%)")
-        self.logger.info(f"  Expansion: {expansion_duration_deg:.1f}° ({100-compression_duration_percent}%)")
+        self.logger.info(
+            "  Compression: %.1f° (%.1f%%)",
+            compression_duration_deg,
+            compression_duration_percent,
+        )
+        self.logger.info(
+            "  Expansion: %.1f° (%.1f%%)",
+            expansion_duration_deg,
+            expansion_duration_percent,
+        )
         
         # Extract physical limits
         max_velocity = motion_params.get('maxVelocity', 100.0)

--- a/campro/optimization/phase2_gear_optimizer.py
+++ b/campro/optimization/phase2_gear_optimizer.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass
 import logging
 import time
 
+from campro.utils.angle_units import (
+    ensure_percent_grid,
+    percent_to_degrees,
+    percent_to_radians,
+    resolve_cycle_percent,
+    degrees_to_percent,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -178,12 +186,14 @@ class Phase2GearOptimizer:
         """Create collocation grid for gear profile optimization."""
         self.logger.info("Creating gear profile collocation grid")
         
-        # Use the same grid as motion law for consistency
-        gear_grid = np.deg2rad(theta_grid)
-        
-        # Ensure proper scaling for gear optimization
-        ring_rotation_deg = gear_params.get('ringRotationDeg', 180.0)
-        scale_factor = 2 * np.pi / ring_rotation_deg
+        # Use the same grid as motion law for consistency but normalise units
+        theta_percent = degrees_to_percent(theta_grid)
+        gear_grid = percent_to_radians(theta_percent)
+
+        ring_rotation_percent = resolve_cycle_percent(
+            gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+        scale_factor = (2 * np.pi) / percent_to_radians(ring_rotation_percent)
         gear_grid = gear_grid * scale_factor
         
         self.logger.info(f"Gear collocation grid created with {len(gear_grid)} points")
@@ -291,9 +301,11 @@ class Phase2GearOptimizer:
         noslip_residual = r_inst * planet_radius - ring_radius
 
         # Global integral residual (use same step)
-        ring_rotation_deg = gear_params.get('ringRotationDeg', 180.0)
-        step_deg = ring_rotation_deg / (n - 1) if n > 1 else ring_rotation_deg
-        integral_r = ca.sum1(r_inst) * step_deg
+        ring_rotation_percent = resolve_cycle_percent(
+            gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+        )
+        step_percent = ring_rotation_percent / (n - 1) if n > 1 else ring_rotation_percent
+        integral_r = ca.sum1(r_inst) * percent_to_radians(step_percent)
         expected_integral = 2.0 * np.pi
         integral_residual = integral_r - expected_integral
 
@@ -682,7 +694,13 @@ class Phase2GearOptimizer:
         if len(theta_grid_deg) > 1:
             step_deg = float(theta_grid_deg[1] - theta_grid_deg[0])
         else:
-            step_deg = float(gear_params.get('ringRotationDeg', 180.0))
+            step_deg = float(
+                percent_to_degrees(
+                    resolve_cycle_percent(
+                        gear_params, 'ringRotation', default_percent=degrees_to_percent(180.0)
+                    )
+                )
+            )
         # Accumulate over intervals to be consistent with the constraint
         if n > 1:
             accumulated_phi_deg = float(np.sum(r_inst[: n - 1]) * step_deg)

--- a/campro/utils/angle_units.py
+++ b/campro/utils/angle_units.py
@@ -1,0 +1,123 @@
+"""Utility helpers for working with angular units.
+
+The historical implementation of the planetary gear optimisation pipeline mixed
+degrees and radians in a number of places.  This frequently resulted in hidden
+unit-conversion bugs whenever caller provided data in a different unit system.
+
+The project now standardises on **percent of ring rotation** as the canonical
+representation for user supplied data (where an entire 2π rotation corresponds
+to ``100%``).  This module provides a small collection of helpers that make it
+easy to convert to and from that representation while still supporting the
+legacy degree and radian inputs that appear throughout older scripts and
+tests.
+
+All conversion functions work with either scalar floats or :mod:`numpy`
+arrays.  Consumers should call :func:`resolve_cycle_percent` to obtain a
+normalised percentage for a particular parameter before performing additional
+unit conversions.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Any, Optional, TypeVar, overload
+
+import numpy as np
+
+FULL_CYCLE_RADIANS = 2.0 * np.pi
+FULL_CYCLE_DEGREES = 360.0
+FULL_CYCLE_PERCENT = 100.0
+
+T = TypeVar("T", float, np.ndarray)
+
+
+def _as_array(value: T) -> np.ndarray:
+    """Return ``value`` as a :class:`numpy.ndarray` without copying when possible."""
+
+    if isinstance(value, np.ndarray):
+        return value
+    return np.asarray(value, dtype=float)
+
+
+def percent_to_radians(value: T) -> T:
+    """Convert a percentage of the cycle to radians."""
+
+    array = _as_array(value) * (FULL_CYCLE_RADIANS / FULL_CYCLE_PERCENT)
+    return array if isinstance(value, np.ndarray) else float(array)
+
+
+def percent_to_degrees(value: T) -> T:
+    """Convert a percentage of the cycle to degrees."""
+
+    array = _as_array(value) * (FULL_CYCLE_DEGREES / FULL_CYCLE_PERCENT)
+    return array if isinstance(value, np.ndarray) else float(array)
+
+
+def degrees_to_percent(value: T) -> T:
+    """Convert degrees of rotation to percent of the cycle."""
+
+    array = _as_array(value) * (FULL_CYCLE_PERCENT / FULL_CYCLE_DEGREES)
+    return array if isinstance(value, np.ndarray) else float(array)
+
+
+def radians_to_percent(value: T) -> T:
+    """Convert radians of rotation to percent of the cycle."""
+
+    array = _as_array(value) * (FULL_CYCLE_PERCENT / FULL_CYCLE_RADIANS)
+    return array if isinstance(value, np.ndarray) else float(array)
+
+
+@overload
+def resolve_cycle_percent(params: Mapping[str, Any], base_key: str) -> float:
+    ...
+
+
+@overload
+def resolve_cycle_percent(
+    params: Mapping[str, Any], base_key: str, default_percent: float
+) -> float:
+    ...
+
+
+def resolve_cycle_percent(
+    params: Mapping[str, Any], base_key: str, default_percent: Optional[float] = None
+) -> float:
+    """Return ``base_key`` expressed as a percentage of the cycle.
+
+    The helper first looks for ``"{base_key}Percent"`` in ``params``.  If that
+    entry does not exist it attempts to resolve ``"{base_key}Deg"`` and
+    ``"{base_key}Rad"`` respectively.  When none of the keys are present the
+    supplied ``default_percent`` is returned.  If no default is provided a
+    :class:`KeyError` is raised to signal the missing configuration.
+    """
+
+    percent_key = f"{base_key}Percent"
+    if percent_key in params:
+        return float(params[percent_key])
+
+    deg_key = f"{base_key}Deg"
+    if deg_key in params:
+        return float(degrees_to_percent(params[deg_key]))
+
+    rad_key = f"{base_key}Rad"
+    if rad_key in params:
+        return float(radians_to_percent(params[rad_key]))
+
+    if default_percent is not None:
+        return default_percent
+
+    raise KeyError(
+        f"Unable to resolve '{base_key}' – expected percent/degree/radian entry"
+    )
+
+
+def ensure_percent_grid(step_percent: float) -> float:
+    """Normalise percentage step sizes.
+
+    ``numpy.arange`` is sensitive to floating-point rounding which can leave the
+    final value just shy of the expected end point.  Normalising the step value
+    through this helper ensures a consistent dtype which in turn keeps the grid
+    construction stable.
+    """
+
+    return float(step_percent)
+


### PR DESCRIPTION
## Summary
- add a shared `angle_units` helper to convert between percent, degrees, and radians while keeping legacy keys working
- drive the gear profile generator entirely from percent-of-cycle inputs and update derivative math to use consistent radians
- update the enhanced motion- and gear-optimization stages to consume percent-based parameters and grids instead of hard-coded degrees

## Testing
- python -m compileall campro/utils/angle_units.py campro/gears/profile_generator.py campro/optimization/enhanced_motion_law_optimizer.py campro/optimization/enhanced_gear_optimizer.py campro/optimization/phase2_gear_optimizer.py


------
https://chatgpt.com/codex/tasks/task_e_68e0143966cc8323855900fcee5d1132