### PR TITLE
Fix B-spline motion law control point handling

### DIFF
--- a/campro/optimization/bspline_motion_law.py
+++ b/campro/optimization/bspline_motion_law.py
@@ -191,73 +191,48 @@ class BSplineMotionLaw:
         Returns:
             Dictionary of motion law functions (position, velocity, acceleration, jerk)
         """
-        # Handle both numpy arrays and CasADi SX
-        if isinstance(control_points, ca.SX):
+        # Handle both numpy arrays and CasADi types
+        if isinstance(control_points, (ca.SX, ca.MX)):
             n_points = control_points.size1()
+            cp_symbol = control_points
+        elif isinstance(control_points, ca.DM):
+            control_points = np.array(control_points.full()).reshape((-1,))
+            n_points = control_points.size
+            cp_symbol = ca.SX.sym('control_points', n_points)
         else:
-            n_points = len(control_points)
-        
+            control_points = np.asarray(control_points).reshape((-1,))
+            n_points = control_points.size
+            cp_symbol = ca.SX.sym('control_points', n_points)
+
         if n_points != self.params.num_control_points:
-            raise ValueError(f"Expected {self.params.num_control_points} control points, "
-                           f"got {n_points}")
-        
+            raise ValueError(
+                f"Expected {self.params.num_control_points} control points, got {n_points}"
+            )
+
         # Create symbolic time variable
         t = ca.SX.sym('t')
-        
-        # For now, use a simplified approach with polynomial interpolation
-        # This ensures boundary conditions are satisfied
-        position = self._create_polynomial_motion_law(t, control_points)
-        
-        # Calculate derivatives
-        velocity = ca.jacobian(position, t)
-        acceleration = ca.jacobian(velocity, t)
-        jerk = ca.jacobian(acceleration, t)
-        
-        # Create CasADi functions
+
+        # Evaluate basis and derivative vectors and project with control points
+        basis_values = self.basis_eval_func(t)[0]
+        velocity_basis = self.velocity_eval_func(t)[0]
+        acceleration_basis = self.acceleration_eval_func(t)[0]
+        jerk_basis = self.jerk_eval_func(t)[0]
+
+        position = ca.dot(basis_values, cp_symbol)
+        velocity = ca.dot(velocity_basis, cp_symbol)
+        acceleration = ca.dot(acceleration_basis, cp_symbol)
+        jerk = ca.dot(jerk_basis, cp_symbol)
+
+        # Create CasADi functions parameterized by control points
         motion_law = {
-            'position': ca.Function('position', [t], [position]),
-            'velocity': ca.Function('velocity', [t], [velocity]),
-            'acceleration': ca.Function('acceleration', [t], [acceleration]),
-            'jerk': ca.Function('jerk', [t], [jerk])
+            'position': ca.Function('position', [t, cp_symbol], [position]),
+            'velocity': ca.Function('velocity', [t, cp_symbol], [velocity]),
+            'acceleration': ca.Function('acceleration', [t, cp_symbol], [acceleration]),
+            'jerk': ca.Function('jerk', [t, cp_symbol], [jerk]),
+            'control_points_symbol': cp_symbol
         }
-        
+
         return motion_law
-    
-    def _create_polynomial_motion_law(self, t: ca.SX, control_points) -> ca.SX:
-        """
-        Create polynomial motion law that satisfies boundary conditions.
-        
-        Args:
-            t: Time variable
-            control_points: Control points
-            
-        Returns:
-            Position as polynomial function of time
-        """
-        # Normalize time to [0, 1]
-        t_norm = t / self.params.cycle_time
-        
-        # Create a polynomial that satisfies boundary conditions
-        # x(0) = 0, x(1) = S, v(0) = 0, v(1) = 0
-        # Use a 4th order polynomial: x(t) = a*t^4 + b*t^3 + c*t^2 + d*t + e
-        
-        # Boundary conditions:
-        # x(0) = 0 -> e = 0
-        # x(1) = S -> a + b + c + d = S
-        # v(0) = 0 -> d = 0
-        # v(1) = 0 -> 4a + 3b + 2c = 0
-        
-        # Solve: a + b + c = S, 4a + 3b + 2c = 0
-        # From the second equation: 4a + 3b + 2c = 0
-        # From the first equation: a + b + c = S
-        # Let c = 0, then: a + b = S, 4a + 3b = 0
-        # Solving: a = -3S, b = 4S
-        
-        S = self.params.stroke_length
-        
-        position = -3*S*t_norm**4 + 4*S*t_norm**3
-        
-        return position
     
     def create_boundary_constraints(self, control_points: ca.SX) -> List[ca.SX]:
         """
@@ -318,11 +293,11 @@ class BSplineMotionLaw:
         
         # Create motion law for constraint evaluation
         motion_law = self.create_motion_law(control_points)
-        
+
         # Evaluate jerk at time grid points
         for t_val in time_grid:
-            jerk_val = motion_law['jerk'](t_val)
-            
+            jerk_val = motion_law['jerk'](t_val, control_points)
+
             # Add jerk bound constraints: |j(t)| ≤ j_max
             constraints.append(jerk_val - self.params.max_jerk)  # j(t) ≤ j_max
             constraints.append(-jerk_val - self.params.max_jerk)  # -j(t) ≤ j_max
@@ -331,8 +306,14 @@ class BSplineMotionLaw:
     
     def create_initial_guess(self) -> np.ndarray:
         """
-        Create initial guess for control points.
-        
+        Create an initial guess that satisfies boundary constraints.
+
+        The first two and last two control points are clamped to the initial and
+        final positions so that the default zero-velocity boundary constraints
+        created by :meth:`create_boundary_constraints` are exactly satisfied.
+        Interior points follow a smooth-step profile to provide a feasible yet
+        gently varying trajectory for the optimizer to refine.
+
         Returns:
             Initial guess for control points
         """
@@ -340,14 +321,21 @@ class BSplineMotionLaw:
         # This ensures the boundary conditions are satisfied
         
         control_points = np.zeros(self.params.num_control_points)
-        
-        # Linear interpolation from 0 to S
-        for i in range(self.params.num_control_points):
-            # Map control point index to time
-            t_ratio = i / (self.params.num_control_points - 1)
-            control_points[i] = self.params.initial_position + \
-                              t_ratio * (self.params.final_position - self.params.initial_position)
-        
+
+        # Enforce clamped boundary values explicitly so v(0) = v(T_cyc) = 0.
+        control_points[0] = control_points[1] = self.params.initial_position
+        control_points[-1] = control_points[-2] = self.params.final_position
+
+        # Fill interior points using a C1-eased ramp to keep derivatives small.
+        if self.params.num_control_points > 4:
+            interior_count = self.params.num_control_points - 4
+            delta = self.params.final_position - self.params.initial_position
+            for idx in range(interior_count):
+                # Normalized parameter in (0, 1) for interior points.
+                s = (idx + 1) / (interior_count + 1)
+                eased = s * s * (3 - 2 * s)  # Smoothstep: zero slope at boundaries.
+                control_points[2 + idx] = self.params.initial_position + delta * eased
+
         return control_points
     
     def evaluate_motion_law(self, control_points: np.ndarray, 
@@ -364,6 +352,11 @@ class BSplineMotionLaw:
         """
         # Create motion law functions
         motion_law = self.create_motion_law(control_points)
+
+        if isinstance(control_points, (ca.SX, ca.MX)):
+            raise TypeError("control_points must be numeric for evaluation")
+
+        cp_vector = ca.DM(np.asarray(control_points).reshape((-1, 1)))
         
         # Evaluate at time grid points
         results = {
@@ -374,10 +367,10 @@ class BSplineMotionLaw:
         }
         
         for i, t_val in enumerate(time_grid):
-            results['position'][i] = float(motion_law['position'](t_val))
-            results['velocity'][i] = float(motion_law['velocity'](t_val))
-            results['acceleration'][i] = float(motion_law['acceleration'](t_val))
-            results['jerk'][i] = float(motion_law['jerk'](t_val))
+            results['position'][i] = float(motion_law['position'](t_val, cp_vector))
+            results['velocity'][i] = float(motion_law['velocity'](t_val, cp_vector))
+            results['acceleration'][i] = float(motion_law['acceleration'](t_val, cp_vector))
+            results['jerk'][i] = float(motion_law['jerk'](t_val, cp_vector))
         
         return results
     
@@ -496,8 +489,10 @@ class BSplineMotionLawOptimizer:
         objective = ca.SX.sym('velocity_flatness_obj', 1)
         objective[0] = 0
         
+        cp_symbol = motion_law['control_points_symbol']
+
         for t_val in time_grid:
-            velocity = motion_law['velocity'](t_val)
+            velocity = motion_law['velocity'](t_val, cp_symbol)
             objective[0] += (velocity - target_velocity)**2
         
         return objective[0]
@@ -518,8 +513,10 @@ class BSplineMotionLawOptimizer:
         objective = ca.SX.sym('jerk_reg_obj', 1)
         objective[0] = 0
         
+        cp_symbol = motion_law['control_points_symbol']
+
         for t_val in time_grid:
-            jerk = motion_law['jerk'](t_val)
+            jerk = motion_law['jerk'](t_val, cp_symbol)
             objective[0] += jerk**2
         
         return objective[0]

--- a/tests/test_bspline_motion_law.py
+++ b/tests/test_bspline_motion_law.py
@@ -99,16 +99,13 @@ class TestBSplineMotionLaw:
         control_points = np.linspace(0, 0.1, bspline.params.num_control_points)
         
         motion_law = bspline.create_motion_law(control_points)
-        
+
         # Check that motion law functions are created
-        assert 'position' in motion_law
-        assert 'velocity' in motion_law
-        assert 'acceleration' in motion_law
-        assert 'jerk' in motion_law
-        
-        # Check that functions are CasADi functions
-        for func_name, func in motion_law.items():
-            assert isinstance(func, ca.Function)
+        for key in ['position', 'velocity', 'acceleration', 'jerk']:
+            assert key in motion_law
+            assert isinstance(motion_law[key], ca.Function)
+
+        assert motion_law['control_points_symbol'].size1() == bspline.params.num_control_points
     
     def test_boundary_constraints(self, bspline):
         """Test boundary constraint creation."""
@@ -127,7 +124,7 @@ class TestBSplineMotionLaw:
     def test_initial_guess_creation(self, bspline):
         """Test initial guess creation."""
         initial_guess = bspline.create_initial_guess()
-        
+
         # Check initial guess shape
         assert len(initial_guess) == bspline.params.num_control_points
         
@@ -137,6 +134,39 @@ class TestBSplineMotionLaw:
         
         # Check that it's a reasonable interpolation
         assert np.all(np.diff(initial_guess) >= 0)  # Non-decreasing
+
+    def test_initial_guess_satisfies_boundary_constraints(self, bspline):
+        """Initial guess should respect position/velocity boundary constraints."""
+        initial_guess = bspline.create_initial_guess()
+        control_points = ca.SX.sym('cp', bspline.params.num_control_points)
+        constraints = bspline.create_boundary_constraints(control_points)
+        constraint_func = ca.Function('boundary', [control_points], [ca.vertcat(*constraints)])
+        residual = np.array(constraint_func(ca.DM(initial_guess).reshape((-1, 1))))
+        assert np.allclose(residual, 0.0, atol=1e-10)
+
+    def test_motion_law_responds_to_control_point_changes(self, bspline):
+        """Perturbing a control point should change the motion law and derivatives."""
+        control_points_symbol = ca.SX.sym('cp', bspline.params.num_control_points)
+        motion_law = bspline.create_motion_law(control_points_symbol)
+
+        baseline = bspline.create_initial_guess()
+        perturbed = baseline.copy()
+        perturbed[3] += 1e-3
+
+        t_sample = 0.4 * bspline.params.cycle_time
+        baseline_dm = ca.DM(baseline).reshape((-1, 1))
+        perturbed_dm = ca.DM(perturbed).reshape((-1, 1))
+
+        pos_base = float(motion_law['position'](t_sample, baseline_dm))
+        pos_pert = float(motion_law['position'](t_sample, perturbed_dm))
+        vel_base = float(motion_law['velocity'](t_sample, baseline_dm))
+        vel_pert = float(motion_law['velocity'](t_sample, perturbed_dm))
+        jerk_base = float(motion_law['jerk'](t_sample, baseline_dm))
+        jerk_pert = float(motion_law['jerk'](t_sample, perturbed_dm))
+
+        assert abs(pos_base - pos_pert) > 1e-8
+        assert abs(vel_base - vel_pert) > 1e-8
+        assert abs(jerk_base - jerk_pert) > 1e-8
     
     def test_motion_law_evaluation(self, bspline):
         """Test motion law evaluation."""


### PR DESCRIPTION
## Summary
- make the B-spline motion law project the basis and derivative matrices onto the provided control points instead of the hard-coded polynomial fallback
- ensure the initial control point guess satisfies the clamped boundary constraints while keeping a smooth interior profile
- extend the unit test suite with coverage for boundary-compatible guesses and control-point sensitivity

## Testing
- `pytest tests/test_bspline_motion_law.py -k "initial_guess_satisfies_boundary_constraints or motion_law_responds_to_control_point_changes" -q` *(fails: pytest-qt requires libGL which is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0118158548323a84c654b130abf19